### PR TITLE
http keep alive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+  - jruby-1.7.25
+jdk:
+  - oraclejdk8
+script: 
+  - bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Logstash REST Filter
 
+[![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=http-keep-alive)](https://travis-ci.org/gandalfb/logstash-filter-rest)
+
 This is a filter plugin for [Logstash](https://github.com/elasticsearch/logstash).
 
 It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Logstash REST Filter
-
-[![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=http-keep-alive)](https://travis-ci.org/gandalfb/logstash-filter-rest)
+# Logstash REST Filter [![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=http-keep-alive)](https://travis-ci.org/gandalfb/logstash-filter-rest)
 
 This is a filter plugin for [Logstash](https://github.com/elasticsearch/logstash).
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ rest {
     "key3" => "%{somefield}"        # Please set sprintf to true if you want to use field references
   }
   response_key => "my_key"          # string (optional, default = "rest_response")
+  fallback => {                     # hash describing a default in case of error
+    "key1" => "value1"
+    "key2" => "value2"
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,25 +27,32 @@ $LS_HOME/bin/plugin install logstash-filter-rest-0.1.0.gem
 Add the following inside the filter section of your logstash configuration:
 
 ```sh
-rest {
-  url => "http://example.com"       # string (required, with field reference: "http://example.com?id=%{id}")
-  json => true                      # boolean (optional, default = false)
-  method => "post"                  # string (optional, default = "get")
-  sprintf => true                   # boolean (optional, default = false, set this to true if you want to use field references in url, header or params)
-  header => {                       # hash (optional)
-    "key1" => "value1"
-    "key2" => "value2"
-    "key3" => "%{somefield}"        # Please set sprintf to true if you want to use field references
-  }
-  params => {                       # hash (optional, only available for method => "post")
-    "key1" => "value1"
-    "key2" => "value2"
-    "key3" => "%{somefield}"        # Please set sprintf to true if you want to use field references
-  }
-  response_key => "my_key"          # string (optional, default = "rest_response")
-  fallback => {                     # hash describing a default in case of error
-    "key1" => "value1"
-    "key2" => "value2"
+filter {
+  rest {
+    request => {
+      url => "http://example.com"       # string (required, with field reference: "http://example.com?id=%{id}" or params, if defined)
+      method => "post"                  # string (optional, default = "get")
+      headers => {                       # hash (optional)
+        "key1" => "value1"
+        "key2" => "value2"
+      }
+      auth => {
+        user => "AzureDiamond"
+        password => "hunter2"
+      }
+      params => {                       # hash (optional, available for method => "get" and "post"; if post it will be transformed into body hash and posted as json)
+        "key1" => "value1"
+        "key2" => "value2"
+        "key3" => "%{somefield}"        # Please set sprintf to true if you want to use field references
+      }
+    }
+    json => true                      # boolean (optional, default = false)
+    sprintf => true                   # boolean (optional, default = false, set this to true if you want to use field references in url, header or params)
+    target => "my_key"          # string (optional, default = "rest_response")
+    fallback => {                     # hash describing a default in case of error
+      "key1" => "value1"
+      "key2" => "value2"
+    }
   }
 }
 ```

--- a/lib/logstash/filters/rest.rb
+++ b/lib/logstash/filters/rest.rb
@@ -1,70 +1,123 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require "logstash/plugin_mixins/http_client"
 require "json"
-require "rest_client"
 
 # Logstash REST Filter
 # This filter calls a defined URL and saves the answer into a specified field.
 #
 class LogStash::Filters::Rest < LogStash::Filters::Base
+  include LogStash::PluginMixins::HttpClient
 
   # Usage:
   #
-  #  rest {
-  #  url => "http://example.com"       # string (required, with field reference: "http://example.com?id=%{id}")
-  #  json => true                      # boolean (optional, default = false)
-  #  method => "post"                  # string (optional, default = "get")
-  #  sprintf => true                   # boolean (optional, default = false, set this to true if you want to use field references in url, header or params)
-  #  header => {                       # hash (optional)
-  #    "key1" => "value1"
-  #    "key2" => "value2"
-  #    "key3" => "%{somefield}"        # Please set sprintf to true if you want to use field references
-  #  }
-  #  params => {                       # hash (optional, only available for method => "post")
-  #    "key1" => "value1"
-  #    "key2" => "value2"
-  #    "key3" => "%{somefield}"        # Please set sprintf to true if you want to use field references
-  #  }
-  #  response_key => "my_key"          # string (optional, default = "rest_response")
-  #  fallback => {                     # hash describing a default in case of error
-  #    "key1" => "value1"
-  #    "key2" => "value2"
-  #  }
-  #  }
-  #
+  # rest {
+  #   request => {
+  #     url => "http://example.com"       # string (required, with field reference: "http://example.com?id=%{id}" or params, if defined)
+  #     method => "post"                  # string (optional, default = "get")
+  #     headers => {                       # hash (optional)
+  #       "key1" => "value1"
+  #       "key2" => "value2"
+  #       "key3" => "%{somefield}"        # Please set sprintf to true if you want to use field references
+  #     }
+  #     auth => {
+  #       user => "AzureDiamond"
+  #       password => "hunter2"
+  #     }
+  #     params => {                       # hash (optional, only available for method => "post")
+  #       "key1" => "value1"
+  #       "key2" => "value2"
+  #       "key3" => "%{somefield}"        # Please set sprintf to true if you want to use field references
+  #     }
+  #   }
+  #   json => true                      # boolean (optional, default = false)
+  #   sprintf => true                   # boolean (optional, default = false, set this to true if you want to use field references in url, header or params)
+  #   response_key => "my_key"          # string (optional, default = "rest_response")
+  #   fallback => {                     # hash describing a default in case of error
+  #     "key1" => "value1"
+  #     "key2" => "value2"
+  #   }
+  # }
   
   config_name "rest"
-  
-  config :url, :validate => :string, :required => true
-  config :method, :validate => :string, :default => "get"
+
+  # configure the rest request send via HttpClient Plugin
+  config :request, :validate => :hash, :required => true
   config :json, :validate => :boolean, :default => false
   config :sprintf, :validate => :boolean, :default => false
-  config :header, :validate => :hash, :default => {  }
-  config :params, :validate => :hash, :default => {  }
   config :response_key, :validate => :string, :default => "rest_response"
   config :fallback, :validate => :hash, :default => {  }
 
   public
   def register
-
+    @request = normalize_request( @request )
   end # def register
 
-  public
-  def filter(event)
-    return unless filter?(event)
-  begin
-    case method
-    when "get"
-      response = RestClient.get sprint(@sprintf, @url, event), sprint(@sprintf, @header, event)
-    when "post"
-      response = RestClient.post sprint(@sprintf, @url, event), sprint(@sprintf, @params, event), sprint(@sprintf, @header, event)
+  private
+  def normalize_request(url_or_spec)
+    if url_or_spec.is_a?(String)
+      res = [:get, url_or_spec]
+    elsif url_or_spec.is_a?(Hash)
+      # The client will expect keys / values
+      spec = Hash[url_or_spec.clone.map {|k,v| [k.to_sym, v] }] # symbolize keys
+
+      # method and url aren't really part of the options, so we pull them out
+      method = (spec.delete(:method) || :get).to_sym.downcase
+      url = spec.delete(:url)
+
+      # if it is a post and json, it is used as body string, not params
+      if method == :post
+        spec[:body] = spec.delete(:params)
+      end
+
+      # We need these strings to be keywords!
+      spec[:auth] = {user: spec[:auth]["user"], pass: spec[:auth]["password"]} if spec[:auth]
+
+      res = [method, url, spec]
     else
-      response = "invalid method"  
-      @logger.error("Invalid method:", :method => method)
+      raise LogStash::ConfigurationError, "Invalid URL or request spec: '#{url_or_spec}', expected a String or Hash!"
     end
-    
-    if json == true
+
+    validate_request!(url_or_spec, res)
+    res
+  end
+
+  private
+  def validate_request!(url_or_spec, request)
+    method, url, spec = request
+
+    raise LogStash::ConfigurationError, "No URL provided for request! #{url_or_spec}" unless url
+    raise LogStash::ConfigurationError, "Not supported request method #{method}" unless [ :get, :post ].include?( method )
+
+    if spec && spec[:auth]
+      if !spec[:auth][:user]
+        raise LogStash::ConfigurationError, "Auth was specified, but 'user' was not!"
+      end
+      if !spec[:auth][:pass]
+        raise LogStash::ConfigurationError, "Auth was specified, but 'password' was not!"
+      end
+    end
+
+    request
+  end
+
+  private
+  def request_http(request)
+    @logger.debug? && @logger.debug("Fetching URL", :request => request)
+
+    if @request[2].key?(:body)
+      @request[2][:body] = @request[2][:body].to_json
+    end
+
+    method, url, *request_opts = request
+    response = client.http(method, url, *request_opts)
+    return response.code, response.body
+  end
+
+  private
+  def process_response(response, event)
+    if @json
       begin
         h = JSON.parse(response)
         if response_key == ""
@@ -72,12 +125,11 @@ class LogStash::Filters::Rest < LogStash::Filters::Base
             event[key] = value
           end
         else
-          event[response_key] = { }
           event[response_key] = h
         end
       rescue
-        if fallback
-          event[@response_key] = fallback
+        if not @fallback.empty?
+          event[@response_key] = @fallback
         else
           event['jsonerror'] = "unable to parse json"
         end
@@ -85,34 +137,51 @@ class LogStash::Filters::Rest < LogStash::Filters::Base
     else
       event[@response_key] = response.strip
     end
-  rescue
-    if fallback
-      event[@response_key] = fallback
-    else
-      @logger.error("Error in Rest Filter. Parameters:", :url => url, :method => method, :json => json, :header => header, :params => params)
-      @logger.error("Rest Error Message:", :message => $!.message)
-      @logger.error("Backtrace:", :backtrace => $!.backtrace)
-      event['resterror'] = "Rest Filter Error. Please see Logstash Error Log for further information."
-    end
+    return event
   end
-  
+
+  public
+  def filter(event)
+    return unless filter?(event)
+    if @request[2].key?(:params)
+      @request[2][:params] = sprint(@sprintf, @request[2][:params], event)
+    end
+    if @request[2].key?(:body)
+      @request[2][:body] = sprint(@sprintf, @request[2][:body], event)
+    end
+    @request[1] = sprint(@sprintf, @request[1], event)
+
+    code, body = request_http(@request)
+    if code.between?(200, 299)
+      @logger.debug? && @logger.debug("Sucess received", :code => code, :body => body)
+      event = process_response( body, event )
+    else
+      @logger.debug? && @logger.debug("Http error received", :code => code, :body => body)
+      if not @fallback.empty?
+        @logger.debug? && @logger.debug("Setting fallback", :fallback => @fallback)
+        event[@response_key] = @fallback
+      else
+        @logger.error("Error in Rest Filter. Parameters:", :request => @request, :json => @json, :code => code, :body => body)
+        event['resterror'] = "Rest Filter Error. Please see Logstash Error Log for further information."
+      end
+    end
     filter_matched(event)
   end # def filter
-  
+
   def sprint(sprintf, hash, event)
-        if sprintf
-                if hash.class == Hash
-                        result = { }
-                        hash.each do |key, value|
-                                result[key] = event.sprintf(value)
-                        end
-                        return result
-                else
-                        return event.sprintf(hash)
-                end
-        else
-                return hash
+    if sprintf
+      if hash.class == Hash
+        result = { }
+        hash.each do |key, value|
+          result[key] = event.sprintf(value)
         end
+        return result
+      else
+        return event.sprintf(hash)
+      end
+    else
+      return hash
+    end
   end
 
 end # class LogStash::Filters::Rest

--- a/lib/logstash/filters/rest.rb
+++ b/lib/logstash/filters/rest.rb
@@ -30,7 +30,7 @@ class LogStash::Filters::Rest < LogStash::Filters::Base
   #            user => "AzureDiamond"
   #            password => "hunter2"
   #          }
-  #          params => {                       # hash (optional, available for method => "get" and "post"; if post it will be transfored into body hash and posted as json)
+  #          params => {                       # hash (optional, available for method => "get" and "post"; if post it will be transformed into body hash and posted as json)
   #            "key1" => "value1"
   #            "key2" => "value2"
   #            "key3" => "%{somefield}"        # Please set sprintf to true if you want to use field references

--- a/lib/logstash/filters/rest.rb
+++ b/lib/logstash/filters/rest.rb
@@ -25,7 +25,6 @@ class LogStash::Filters::Rest < LogStash::Filters::Base
   #          headers => {                       # hash (optional)
   #            "key1" => "value1"
   #            "key2" => "value2"
-  #            "key3" => "%{somefield}"        # Please set sprintf to true if you want to use field references
   #          }
   #          auth => {
   #            user => "AzureDiamond"
@@ -97,7 +96,7 @@ class LogStash::Filters::Rest < LogStash::Filters::Base
   #         }
   #       }
   #     }
-  config :fallback, :validate => :hash, :default => { }
+  config :fallback, :validate => :hash, :default => {}
 
   # Append values to the `tags` field when there has been no
   # successful match or json parsing error

--- a/lib/logstash/filters/rest.rb
+++ b/lib/logstash/filters/rest.rb
@@ -48,41 +48,41 @@ class LogStash::Filters::Rest < LogStash::Filters::Base
   public
   def filter(event)
     return unless filter?(event)
-	begin
-		case method
-		when "get"
-			response = RestClient.get sprint(@sprintf, @url, event), sprint(@sprintf, @header, event)
-		when "post"
-			response = RestClient.post sprint(@sprintf, @url, event), sprint(@sprintf, @params, event), sprint(@sprintf, @header, event)
-		else
-			response = "invalid method"	
-			@logger.error("Invalid method:", :method => method)
-		end
-		
-		if json == true
-			begin
-				h = JSON.parse(response)
-				if response_key == ""
-					h.each do |key, value|
-						event[key] = value
-					end
-				else
-					event[response_key] = { }
-					event[response_key] = h
-				end
-			rescue
-				event['jsonerror'] = "unable to parse json"
-			end
-		else
-			event[@response_key] = response.strip
-		end
-	rescue
-		@logger.error("Error in Rest Filter. Parameters:", :url => url, :method => method, :json => json, :header => header, :params => params)
-		@logger.error("Rest Error Message:", :message => $!.message)
-		@logger.error("Backtrace:", :backtrace => $!.backtrace)
-		event['resterror'] = "Rest Filter Error. Please see Logstash Error Log for further information."
-	end
-	
+  begin
+    case method
+    when "get"
+      response = RestClient.get sprint(@sprintf, @url, event), sprint(@sprintf, @header, event)
+    when "post"
+      response = RestClient.post sprint(@sprintf, @url, event), sprint(@sprintf, @params, event), sprint(@sprintf, @header, event)
+    else
+      response = "invalid method"  
+      @logger.error("Invalid method:", :method => method)
+    end
+    
+    if json == true
+      begin
+        h = JSON.parse(response)
+        if response_key == ""
+          h.each do |key, value|
+            event[key] = value
+          end
+        else
+          event[response_key] = { }
+          event[response_key] = h
+        end
+      rescue
+        event['jsonerror'] = "unable to parse json"
+      end
+    else
+      event[@response_key] = response.strip
+    end
+  rescue
+    @logger.error("Error in Rest Filter. Parameters:", :url => url, :method => method, :json => json, :header => header, :params => params)
+    @logger.error("Rest Error Message:", :message => $!.message)
+    @logger.error("Backtrace:", :backtrace => $!.backtrace)
+    event['resterror'] = "Rest Filter Error. Please see Logstash Error Log for further information."
+  end
+  
     filter_matched(event)    
   end # def filter
   

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.5.0', '< 3.0.0'
-  s.add_runtime_dependency "rest-client", '>= 1.8.0'
-  s.add_runtime_dependency 'logstash-codec-json'
-  s.add_development_dependency 'logstash-devutils'
+  s.add_runtime_dependency "rest-client", '>= 1.8.0', '< 2.0.0'
+  s.add_runtime_dependency 'logstash-codec-json', '~> 0'
+  s.add_development_dependency 'logstash-devutils', '~> 0'
 end

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # Files
-  s.files = `git ls-files`.split($\)
+  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-rest'
-  s.version         = '0.1.6'
+  s.version         = '0.2.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This filter requests data from a RESTful Web Service."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -19,7 +19,10 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.6.0', '< 3.0.0'
-  s.add_runtime_dependency "rest-client", '>= 1.8.0', '< 2.0.0'
   s.add_runtime_dependency 'logstash-codec-json', '>= 1.6.0', '< 3.0.0'
+  s.add_runtime_dependency 'logstash-mixin-http_client', ">= 2.2.4", "< 5.0.0"
+
   s.add_development_dependency 'logstash-devutils', '~> 0'
+  s.add_development_dependency 'pry', '~> 0'
+  s.add_development_dependency 'flores', '~> 0'
 end

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", '>= 1.5.0', '< 3.0.0'
+  s.add_runtime_dependency "logstash-core", '>= 1.6.0', '< 3.0.0'
   s.add_runtime_dependency "rest-client", '>= 1.8.0', '< 2.0.0'
-  s.add_runtime_dependency 'logstash-codec-json', '~> 0'
+  s.add_runtime_dependency 'logstash-codec-json', '>= 1.6.0', '< 3.0.0'
   s.add_development_dependency 'logstash-devutils', '~> 0'
 end

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -1,28 +1,28 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-rest'
-  s.version         = '0.2.0'
+  s.version = '0.2.0'
   s.licenses = ['Apache License (2.0)']
-  s.summary = "This filter requests data from a RESTful Web Service."
-  s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
-  s.authors = ["Lucas Henning"]
+  s.summary = 'This filter requests data from a RESTful Web Service.'
+  s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program'
+  s.authors = ['Lucas Henning', 'Gandalf Buscher']
   s.email = 'mail@hurb.de'
-  s.homepage = "https://github.com/lucashenning/logstash-filter-rest/"
-  s.require_paths = ["lib"]
+  s.homepage = 'https://github.com/lucashenning/logstash-filter-rest/'
+  s.require_paths = ['lib']
 
   # Files
   s.files = `git ls-files`.split($\)
-   # Tests
+  # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   # Special flag to let us know this is actually a logstash plugin
-  s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
+  s.metadata = { 'logstash_plugin' => 'true', 'logstash_group' => 'filter' }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", '>= 1.6.0', '< 3.0.0'
+  s.add_runtime_dependency 'logstash-core', '>= 1.6.0', '< 3.0.0'
   s.add_runtime_dependency 'logstash-codec-json', '>= 1.6.0', '< 3.0.0'
-  s.add_runtime_dependency 'logstash-mixin-http_client', ">= 2.2.4", "< 5.0.0"
+  s.add_runtime_dependency 'logstash-mixin-http_client', '>= 2.2.4', '< 5.0.0'
+  s.add_runtime_dependency 'logstash/json', '>= 2.2.4', '< 5.0.0'
 
   s.add_development_dependency 'logstash-devutils', '~> 0'
   s.add_development_dependency 'pry', '~> 0'
-  s.add_development_dependency 'flores', '~> 0'
 end

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-core', '>= 1.6.0', '< 3.0.0'
   s.add_runtime_dependency 'logstash-codec-json', '>= 1.6.0', '< 3.0.0'
   s.add_runtime_dependency 'logstash-mixin-http_client', '>= 2.2.4', '< 5.0.0'
-  s.add_runtime_dependency 'logstash/json', '>= 2.2.4', '< 5.0.0'
 
   s.add_development_dependency 'logstash-devutils', '~> 0'
   s.add_development_dependency 'pry', '~> 0'

--- a/spec/filters/rest_spec.rb
+++ b/spec/filters/rest_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require "logstash/filters/rest"
+require 'logstash/filters/rest'
 
 describe LogStash::Filters::Rest do
   describe "Set to Rest Filter Get without params" do
@@ -16,10 +16,31 @@ describe LogStash::Filters::Rest do
     end
 
     sample("message" => "some text") do
-      expect(subject).to include("rest_response")
-      expect(subject['rest_response']).to include("id")
-      expect(subject['rest_response']['id']).to eq(10)
-      expect(subject['rest_response']).to_not include("fallback")
+      expect(subject).to include('rest')
+      expect(subject['rest']).to include("id")
+      expect(subject['rest']['id']).to eq(10)
+      expect(subject['rest']).to_not include("fallback")
+    end
+  end
+  describe "Set to Rest Filter Get without params custom target" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => "http://jsonplaceholder.typicode.com/users/10"
+          }
+          json => true
+          target => 'testing'
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "some text") do
+      expect(subject).to include('testing')
+      expect(subject['testing']).to include("id")
+      expect(subject['testing']['id']).to eq(10)
+      expect(subject['testing']).to_not include("fallback")
     end
   end
   describe "Set to Rest Filter Get without params and sprintf" do
@@ -37,10 +58,10 @@ describe LogStash::Filters::Rest do
     end
 
     sample("message" => "10") do
-      expect(subject).to include("rest_response")
-      expect(subject['rest_response']).to include("id")
-      expect(subject['rest_response']['id']).to eq(10)
-      expect(subject['rest_response']).to_not include("fallback")
+      expect(subject).to include('rest')
+      expect(subject['rest']).to include("id")
+      expect(subject['rest']['id']).to eq(10)
+      expect(subject['rest']).to_not include("fallback")
     end
   end
   describe "Set to Rest Filter Get without params http error" do
@@ -57,8 +78,8 @@ describe LogStash::Filters::Rest do
     end
 
     sample("message" => "some text") do
-      expect(subject).to_not include("rest_response")
-      expect(subject).to include("resterror")
+      expect(subject).to_not include('rest')
+      expect(subject['tags']).to include('_restfailure')
     end
   end
   describe "Set to Rest Filter Get with params" do
@@ -67,7 +88,7 @@ describe LogStash::Filters::Rest do
         rest {
           request => {
             url => "https://jsonplaceholder.typicode.com/posts"
-            params => { 
+            params => {
               userId => 10
             }
             headers => {
@@ -81,10 +102,10 @@ describe LogStash::Filters::Rest do
     end
 
     sample("message" => "some text") do
-      expect(subject).to include("rest_response")
-      expect(subject['rest_response'][0]).to include("userId")
-      expect(subject['rest_response'][0]['userId']).to eq(10)
-      expect(subject['rest_response']).to_not include("fallback")
+      expect(subject).to include('rest')
+      expect(subject['rest'][0]).to include("userId")
+      expect(subject['rest'][0]['userId']).to eq(10)
+      expect(subject['rest']).to_not include("fallback")
     end
   end
   describe "Set to Rest Filter Get with params sprintf" do
@@ -93,7 +114,7 @@ describe LogStash::Filters::Rest do
         rest {
           request => {
             url => "https://jsonplaceholder.typicode.com/posts"
-            params => { 
+            params => {
               userId => "%{message}"
             }
             headers => {
@@ -108,10 +129,10 @@ describe LogStash::Filters::Rest do
     end
 
     sample("message" => "10") do
-      expect(subject).to include("rest_response")
-      expect(subject['rest_response'][0]).to include("userId")
-      expect(subject['rest_response'][0]['userId']).to eq(10)
-      expect(subject['rest_response']).to_not include("fallback")
+      expect(subject).to include('rest')
+      expect(subject['rest'][0]).to include("userId")
+      expect(subject['rest'][0]['userId']).to eq(10)
+      expect(subject['rest']).to_not include("fallback")
     end
   end
   describe "Set to Rest Filter Post with params" do
@@ -121,7 +142,7 @@ describe LogStash::Filters::Rest do
           request => {
             url => "https://jsonplaceholder.typicode.com/posts"
             method => "post"
-            params => { 
+            params => {
               title => 'foo'
               body => 'bar'
               userId => 42
@@ -137,10 +158,10 @@ describe LogStash::Filters::Rest do
     end
 
     sample("message" => "some text") do
-      expect(subject).to include("rest_response")
-      expect(subject['rest_response']).to include("id")
-      expect(subject['rest_response']['userId']).to eq(42)
-      expect(subject['rest_response']).to_not include("fallback")
+      expect(subject).to include('rest')
+      expect(subject['rest']).to include("id")
+      expect(subject['rest']['userId']).to eq(42)
+      expect(subject['rest']).to_not include("fallback")
     end
   end
   describe "Set to Rest Filter Post with params sprintf" do
@@ -150,7 +171,7 @@ describe LogStash::Filters::Rest do
           request => {
             url => "https://jsonplaceholder.typicode.com/posts"
             method => "post"
-            params => { 
+            params => {
               title => 'foo'
               body => 'bar'
               userId => "%{message}"
@@ -167,10 +188,10 @@ describe LogStash::Filters::Rest do
     end
 
     sample("message" => "42") do
-      expect(subject).to include("rest_response")
-      expect(subject['rest_response']).to include("id")
-      expect(subject['rest_response']['userId']).to eq(42)
-      expect(subject['rest_response']).to_not include("fallback")
+      expect(subject).to include('rest')
+      expect(subject['rest']).to include("id")
+      expect(subject['rest']['userId']).to eq(42)
+      expect(subject['rest']).to_not include("fallback")
     end
   end
   describe "Fallback" do
@@ -191,13 +212,38 @@ describe LogStash::Filters::Rest do
     end
 
     sample("message" => "some text") do
-      expect(subject).to include("rest_response")
-      expect(subject['rest_response']).to include("fallback1")
-      expect(subject['rest_response']).to include("fallback2")
-      expect(subject['rest_response']).to_not include("id")
+      expect(subject).to include('rest')
+      expect(subject['rest']).to include("fallback1")
+      expect(subject['rest']).to include("fallback2")
+      expect(subject['rest']).to_not include("id")
     end
   end
-  describe "Empty response_key" do
+  describe "Fallback empty target" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => "http://jsonplaceholder.typicode.com/users/0"
+          }
+          json => true
+          target => ''
+          fallback => {
+            "fallback1" => true
+            "fallback2" => true
+          }
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "some text") do
+      expect(subject).to_not include('rest')
+      expect(subject).to include("fallback1")
+      expect(subject).to include("fallback2")
+      expect(subject).to_not include("id")
+    end
+  end
+  describe "Empty target" do
     let(:config) do <<-CONFIG
       filter {
         rest {
@@ -205,7 +251,7 @@ describe LogStash::Filters::Rest do
             url => "http://jsonplaceholder.typicode.com/users/1"
           }
           json => true
-          response_key => ""
+          target => ''
         }
       }
     CONFIG

--- a/spec/filters/rest_spec.rb
+++ b/spec/filters/rest_spec.rb
@@ -16,6 +16,44 @@ describe LogStash::Filters::Rest do
     sample("message" => "some text") do
       expect(subject).to include("rest_response")
       expect(subject['rest_response']).to include("id")
+      expect(subject['rest_response']).to_not include("fallback")
+    end
+  end
+  describe "Fallback" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          url => "http://jsonplaceholder.typicode.com/users/0"
+          json => true
+          fallback => {
+            "fallback" => true
+          }
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "some text") do
+      expect(subject).to include("rest_response")
+      expect(subject['rest_response']).to include("fallback")
+      expect(subject['rest_response']).to_not include("id")
+    end
+  end
+  describe "Empty response_key" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          url => "http://jsonplaceholder.typicode.com/users/1"
+          json => true
+          response_key => ""
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "some text") do
+      expect(subject).to include("id")
+      expect(subject).to_not include("fallback")
     end
   end
 end

--- a/spec/filters/rest_spec.rb
+++ b/spec/filters/rest_spec.rb
@@ -2,11 +2,13 @@ require 'spec_helper'
 require "logstash/filters/rest"
 
 describe LogStash::Filters::Rest do
-  describe "Set to Rest Filter" do
+  describe "Set to Rest Filter Get without params" do
     let(:config) do <<-CONFIG
       filter {
         rest {
-          url => "http://jsonplaceholder.typicode.com/users/1"
+          request => {
+            url => "http://jsonplaceholder.typicode.com/users/10"
+          }
           json => true
         }
       }
@@ -16,6 +18,158 @@ describe LogStash::Filters::Rest do
     sample("message" => "some text") do
       expect(subject).to include("rest_response")
       expect(subject['rest_response']).to include("id")
+      expect(subject['rest_response']['id']).to eq(10)
+      expect(subject['rest_response']).to_not include("fallback")
+    end
+  end
+  describe "Set to Rest Filter Get without params and sprintf" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => "http://jsonplaceholder.typicode.com/users/%{message}"
+          }
+          json => true
+          sprintf => true
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "10") do
+      expect(subject).to include("rest_response")
+      expect(subject['rest_response']).to include("id")
+      expect(subject['rest_response']['id']).to eq(10)
+      expect(subject['rest_response']).to_not include("fallback")
+    end
+  end
+  describe "Set to Rest Filter Get without params http error" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => "http://httpstat.us/404"
+          }
+          json => true
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "some text") do
+      expect(subject).to_not include("rest_response")
+      expect(subject).to include("resterror")
+    end
+  end
+  describe "Set to Rest Filter Get with params" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => "https://jsonplaceholder.typicode.com/posts"
+            params => { 
+              userId => 10
+            }
+            headers => {
+              "Content-Type" => "application/json"
+            }
+          }
+          json => true
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "some text") do
+      expect(subject).to include("rest_response")
+      expect(subject['rest_response'][0]).to include("userId")
+      expect(subject['rest_response'][0]['userId']).to eq(10)
+      expect(subject['rest_response']).to_not include("fallback")
+    end
+  end
+  describe "Set to Rest Filter Get with params sprintf" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => "https://jsonplaceholder.typicode.com/posts"
+            params => { 
+              userId => "%{message}"
+            }
+            headers => {
+              "Content-Type" => "application/json"
+            }
+          }
+          json => true
+          sprintf => true
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "10") do
+      expect(subject).to include("rest_response")
+      expect(subject['rest_response'][0]).to include("userId")
+      expect(subject['rest_response'][0]['userId']).to eq(10)
+      expect(subject['rest_response']).to_not include("fallback")
+    end
+  end
+  describe "Set to Rest Filter Post with params" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => "https://jsonplaceholder.typicode.com/posts"
+            method => "post"
+            params => { 
+              title => 'foo'
+              body => 'bar'
+              userId => 42
+            }
+            headers => {
+              "Content-Type" => "application/json"
+            }
+          }
+          json => true
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "some text") do
+      expect(subject).to include("rest_response")
+      expect(subject['rest_response']).to include("id")
+      expect(subject['rest_response']['userId']).to eq(42)
+      expect(subject['rest_response']).to_not include("fallback")
+    end
+  end
+  describe "Set to Rest Filter Post with params sprintf" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => "https://jsonplaceholder.typicode.com/posts"
+            method => "post"
+            params => { 
+              title => 'foo'
+              body => 'bar'
+              userId => "%{message}"
+            }
+            headers => {
+              "Content-Type" => "application/json"
+            }
+          }
+          json => true
+          sprintf => true
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "42") do
+      expect(subject).to include("rest_response")
+      expect(subject['rest_response']).to include("id")
+      expect(subject['rest_response']['userId']).to eq(42)
       expect(subject['rest_response']).to_not include("fallback")
     end
   end
@@ -23,10 +177,13 @@ describe LogStash::Filters::Rest do
     let(:config) do <<-CONFIG
       filter {
         rest {
-          url => "http://jsonplaceholder.typicode.com/users/0"
+          request => {
+            url => "http://jsonplaceholder.typicode.com/users/0"
+          }
           json => true
           fallback => {
-            "fallback" => true
+            "fallback1" => true
+            "fallback2" => true
           }
         }
       }
@@ -35,7 +192,8 @@ describe LogStash::Filters::Rest do
 
     sample("message" => "some text") do
       expect(subject).to include("rest_response")
-      expect(subject['rest_response']).to include("fallback")
+      expect(subject['rest_response']).to include("fallback1")
+      expect(subject['rest_response']).to include("fallback2")
       expect(subject['rest_response']).to_not include("id")
     end
   end
@@ -43,7 +201,9 @@ describe LogStash::Filters::Rest do
     let(:config) do <<-CONFIG
       filter {
         rest {
-          url => "http://jsonplaceholder.typicode.com/users/1"
+          request => {
+            url => "http://jsonplaceholder.typicode.com/users/1"
+          }
           json => true
           response_key => ""
         }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,2 @@
 require "logstash/devutils/rspec/spec_helper"
+require 'pry'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
-require "logstash/devutils/rspec/spec_helper"
+require 'logstash/devutils/rspec/spec_helper'
 require 'pry'


### PR DESCRIPTION
I had the behaviour of the `rest_client` not using http-keep-alive. Leading to a really inefficient connection usage and poor performance.

On the `http_poller` plugin I stumbled upon the mixing `HTTPClient`, which supports this.

So I made some changes on the config section, with - maybe - including some "logstash" style documentation. Validation and request setup mostly is sourced from the `http_poller` plugin, but omitting the url regex check, to support field references.

Further changes:
- `response_key`renamed to `target` which is used by other logstash plugins as well
- error handling via event tags, not fields
  - json or rest errors can be set to custom tags (array)
- `fallback` functionality to add a default hash, in case of http error (http code not 200 to 299) or json error
- `request` represents the `HTTPClient` config
- it is focussed on json
  - if it is `post`, the `params`are saved as `body`and dumped as json
  - for json the Logstash::JSON is used instead of "require json"
  - string only functionality is not well evolved
- extended test cases with travis-ci usage
- `params`may also be used for a `get`
- url, body, params are sprintf'ed
- remove git client dependency within `.gemspec`; this lead to errors once installing the plugin on a remote server without git

First "live" tests in an integration env show quite a performance boost and a really small number of tcp connections (1 or 2 reused connections instead of ~400 waiting connections), which solves my initial issue including a fallback handling.
Further parameters are also configurable within the Manticore object (`request`) => [logstash-mixin-http_client](https://github.com/logstash-plugins/logstash-mixin-http_client)

Maybe this is something useful, although the config syntax is changed, implicating a major version?
