### PR TITLE
bugfix/0.2.0/wrong variable usage

### DIFF
--- a/lib/logstash/filters/rest.rb
+++ b/lib/logstash/filters/rest.rb
@@ -106,7 +106,7 @@ class LogStash::Filters::Rest < LogStash::Filters::Base
   public
 
   def register
-    @request = normalize_request(@request)
+    @request = normalize_request(@request).freeze
   end # def register
 
   private
@@ -190,7 +190,7 @@ class LogStash::Filters::Rest < LogStash::Filters::Base
 
   def filter(event)
     return unless filter?(event)
-    request = @request.clone
+    request = @request.dup
     request[2][:params] = sprint(@sprintf, @request[2][:params], event) if request[2].key?(:params)
     request[2][:body] = sprint(@sprintf, @request[2][:body], event) if request[2].key?(:body)
     request[1] = sprint(@sprintf, @request[1], event)

--- a/spec/filters/rest_spec.rb
+++ b/spec/filters/rest_spec.rb
@@ -63,6 +63,12 @@ describe LogStash::Filters::Rest do
       expect(subject['rest']['id']).to eq(10)
       expect(subject['rest']).to_not include("fallback")
     end
+    sample("message" => "9") do
+      expect(subject).to include('rest')
+      expect(subject['rest']).to include("id")
+      expect(subject['rest']['id']).to eq(9)
+      expect(subject['rest']).to_not include("fallback")
+    end
   end
   describe "Set to Rest Filter Get without params http error" do
     let(:config) do <<-CONFIG
@@ -132,6 +138,12 @@ describe LogStash::Filters::Rest do
       expect(subject).to include('rest')
       expect(subject['rest'][0]).to include("userId")
       expect(subject['rest'][0]['userId']).to eq(10)
+      expect(subject['rest']).to_not include("fallback")
+    end
+    sample("message" => "9") do
+      expect(subject).to include('rest')
+      expect(subject['rest'][0]).to include("userId")
+      expect(subject['rest'][0]['userId']).to eq(9)
       expect(subject['rest']).to_not include("fallback")
     end
   end


### PR DESCRIPTION
Hm it struck me this night, that I used the wrong variable for the request building.
If `sprintf` is active, currently always the same url is requested once logstash has been started 😞 
This is fixed by copying the instance request object and then `sprintf` out the parameters.

The test cases need to be adapted, as the changed setup does not catch this as well...
Sorry for only realising this now. 
