### PR TITLE
bugfix/request-handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Logstash REST Filter [![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=http-keep-alive)](https://travis-ci.org/gandalfb/logstash-filter-rest)
+# Logstash REST Filter [![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=bugfix%2Frequest-handling)](https://travis-ci.org/gandalfb/logstash-filter-rest)
 
 This is a filter plugin for [Logstash](https://github.com/elasticsearch/logstash).
 

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-rest'
-  s.version = '0.2.1'
+  s.version = '0.2.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program'

--- a/spec/filters/rest_spec.rb
+++ b/spec/filters/rest_spec.rb
@@ -206,6 +206,36 @@ describe LogStash::Filters::Rest do
       expect(subject['rest']).to_not include("fallback")
     end
   end
+  describe "Set to Rest Filter Post with body sprintf" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => "https://jsonplaceholder.typicode.com/posts"
+            method => "post"
+            body => {
+              title => 'foo'
+              body => 'bar'
+              userId => "%{message}"
+            }
+            headers => {
+              "Content-Type" => "application/json"
+            }
+          }
+          json => true
+          sprintf => true
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "42") do
+      expect(subject).to include('rest')
+      expect(subject['rest']).to include("id")
+      expect(subject['rest']['userId']).to eq(42)
+      expect(subject['rest']).to_not include("fallback")
+    end
+  end
   describe "Fallback" do
     let(:config) do <<-CONFIG
       filter {


### PR DESCRIPTION
And another one...
This focuses on insight gained from #10 and fixes this wrong behavior.

By freezing `@request` and the inlaying elements (correctly), any unwanted change of the original request with a field reference to `sprintf` is revealed, even if `rspec` is using a new instance for each testcase.
Maybe there is a better way instead of using `Marshal`.

With this the request handling, especially for `sprintf`, should be (more) correct.

I was able to verify functionality within logstash with those minimal examples and the testcases:

``` bash
$ bin/logstash-plugin list --verbose | grep rest
logstash-filter-rest (0.2.2)
```

``` bash
bin/logstash --debug -e 'input { stdin{} } filter { rest { request => { url => "https://jsonplaceholder.typicode.com/posts" method => "post" params => { "userId" => "%{message}" } headers => { "Content-Type" => "application/json" } } json => true sprintf => true } } output {stdout { codec => rubydebug }}'
```

``` bash
bin/logstash --debug -e 'input { stdin{} } filter { rest { request => { url => "https://jsonplaceholder.typicode.com/posts" method => "post" body => { "userId" => "%{message}" } headers => { "Content-Type" => "application/json" } } json => true sprintf => true } } output {stdout { codec => rubydebug }}'
```

``` bash
bin/logstash --debug -e 'input { stdin{} } filter { rest { request => { url => "http://jsonplaceholder.typicode.com/users/%{message}" } json => true sprintf => true } } output {stdout { codec => rubydebug }}'
```

``` bash
bin/logstash --debug -e 'input { stdin{} } filter { rest { request => { url => "https://jsonplaceholder.typicode.com/posts" method => "get" params => { "userId" => "%{message}" } headers => { "Content-Type" => "application/json" } } json => true sprintf => true } } output {stdout { codec => rubydebug }}'
```
