### PR TITLE
Version/logstash 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,6 @@
   - Implicit `sprintf`, deprecating the setting
   - `target` is now required, dropping support to write into top-level in favor of only using new Event API
     - this follows other logstash-plugins like `logstash-filter-json`
+  - if the response is empty, add the restfailure tags
   - Some logging moved before code
   - Testcases adapted to new behavior with error check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.5.0
+  - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
+  - Require devutils >= 0 to make `bundler` update the package
+  - Use Event API for LS-5
+  - Implicit `sprintf`, deprecating the setting
+  - `target` is now required, dropping support to write into top-level in favor of only using new Event API
+    - this follows other logstash-plugins like `logstash-filter-json`
+  - Some logging moved before code
+  - Testcases adapted to new behavior with error check

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Logstash REST Filter [![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=feature%2Fpassive-sprintf)](https://travis-ci.org/gandalfb/logstash-filter-rest)
+# Logstash REST Filter [![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=version%2Flogstash-5)](https://travis-ci.org/gandalfb/logstash-filter-rest)
 
 This is a filter plugin for [Logstash](https://github.com/elasticsearch/logstash).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Logstash REST Filter [![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=http-keep-alive)](https://travis-ci.org/gandalfb/logstash-filter-rest)
+# Logstash REST Filter [![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=bugfix%2Frequest-handling)](https://travis-ci.org/gandalfb/logstash-filter-rest)
 
 This is a filter plugin for [Logstash](https://github.com/elasticsearch/logstash).
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Add the following inside the filter section of your logstash configuration:
 filter {
   rest {
     request => {
-      url => "http://example.com"       # string (required, with field reference: "http://example.com?id=%{id}" or params, if defined)
-      method => "post"                  # string (optional, default = "get")
+      url => "http://example.com"        # string (required, with field reference: "http://example.com?id=%{id}" or params, if defined)
+      method => "post"                   # string (optional, default = "get")
       headers => {                       # hash (optional)
         "key1" => "value1"
         "key2" => "value2"
@@ -40,15 +40,15 @@ filter {
         user => "AzureDiamond"
         password => "hunter2"
       }
-      params => {                       # hash (optional, available for method => "get" and "post"; if post it will be transformed into body hash and posted as json)
+      params => {                        # hash (optional, available for method => "get" and "post"; if post it will be transformed into body hash and posted as json)
         "key1" => "value1"
         "key2" => "value2"
-        "key3" => "%{somefield}"        # Please set sprintf to true if you want to use field references
+        "key3" => "%{somefield}"         # sprintf is used implicitly
       }
     }
-    json => true                      # boolean (optional, default = false)
-    target => "my_key"          # string (optional, default = "rest_response")
-    fallback => {                     # hash describing a default in case of error
+    json => true                         # boolean (optional, default = true)
+    target => "my_key"                   # string (mandatory, no default)
+    fallback => {                        # hash describing a default in case of error
       "key1" => "value1"
       "key2" => "value2"
     }
@@ -56,11 +56,30 @@ filter {
 }
 ```
 
-Example config for running Logstash in `cli`:
+Print plugin version:
 
-```sh
-bin/logstash --debug -e 'input { stdin{} } filter { rest { request => { url => "https://jsonplaceholder.typicode.com/posts" method => "post" params => { "userId" => "%{message}" } headers => { "Content-Type" => "application/json" } } json => true sprintf => true target => 'rest' } } output {stdout { codec => rubydebug }}'
+``` bash
+bin/logstash-plugin list --verbose | grep rest
 ```
+
+Examples for running logstash from `cli`:
+
+``` bash
+bin/logstash --debug -e 'input { stdin{} } filter { rest { request => { url => "https://jsonplaceholder.typicode.com/posts" method => "post" params => { "userId" => "%{message}" } headers => { "Content-Type" => "application/json" } } target => 'rest' } } output {stdout { codec => rubydebug }}'
+```
+
+``` bash
+bin/logstash --debug -e 'input { stdin{} } filter { rest { request => { url => "https://jsonplaceholder.typicode.com/posts" method => "post" body => { "userId" => "%{message}" } headers => { "Content-Type" => "application/json" } } target => 'rest' } } output {stdout { codec => rubydebug }}'
+```
+
+``` bash
+bin/logstash --debug -e 'input { stdin{} } filter { rest { request => { url => "http://jsonplaceholder.typicode.com/users/%{message}" } target => 'rest' } } output {stdout { codec => rubydebug }}'
+```
+
+``` bash
+bin/logstash --debug -e 'input { stdin{} } filter { rest { request => { url => "https://jsonplaceholder.typicode.com/posts" method => "get" params => { "userId" => "%{message}" } headers => { "Content-Type" => "application/json" } } target => 'rest' } } output {stdout { codec => rubydebug }}'
+```
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Logstash REST Filter [![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=feature%2passive-sprintf)](https://travis-ci.org/gandalfb/logstash-filter-rest)
+# Logstash REST Filter [![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=feature%2Fpassive-sprintf)](https://travis-ci.org/gandalfb/logstash-filter-rest)
 
 This is a filter plugin for [Logstash](https://github.com/elasticsearch/logstash).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Logstash REST Filter [![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=bugfix%2Frequest-handling)](https://travis-ci.org/gandalfb/logstash-filter-rest)
+# Logstash REST Filter [![Build Status](https://travis-ci.org/gandalfb/logstash-filter-rest.svg?branch=feature%2passive-sprintf)](https://travis-ci.org/gandalfb/logstash-filter-rest)
 
 This is a filter plugin for [Logstash](https://github.com/elasticsearch/logstash).
 
@@ -47,7 +47,6 @@ filter {
       }
     }
     json => true                      # boolean (optional, default = false)
-    sprintf => true                   # boolean (optional, default = false, set this to true if you want to use field references in url, header or params)
     target => "my_key"          # string (optional, default = "rest_response")
     fallback => {                     # hash describing a default in case of error
       "key1" => "value1"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ filter {
 }
 ```
 
+Example config for running Logstash in `cli`:
+
+```sh
+bin/logstash --debug -e 'input { stdin{} } filter { rest { request => { url => "https://jsonplaceholder.typicode.com/posts" method => "post" params => { "userId" => "%{message}" } headers => { "Content-Type" => "application/json" } } json => true sprintf => true target => 'rest' } } output {stdout { codec => rubydebug }}'
+```
+
 ## Contributing
 
 All contributions are welcome: ideas, patches, documentation, bug reports, complaints, and even something you drew up on a napkin.

--- a/lib/logstash/filters/rest.rb
+++ b/lib/logstash/filters/rest.rb
@@ -233,7 +233,13 @@ class LogStash::Filters::Rest < LogStash::Filters::Base
     if @json
       begin
         parsed = LogStash::Json.load(response)
-        event.set(@target, parsed)
+        if parsed.empty?
+          @logger.warn('rest response empty',
+                       :response => response, :event => event)
+          @tag_on_rest_failure.each { |tag| event.tag(tag) }
+        else
+          event.set(@target, parsed)
+        end
       rescue
         if @fallback.empty?
           @logger.warn('JSON parsing error',

--- a/lib/logstash/filters/rest.rb
+++ b/lib/logstash/filters/rest.rb
@@ -4,6 +4,7 @@ require 'logstash/namespace'
 require 'logstash/plugin_mixins/http_client'
 require 'logstash/json'
 
+#TODO: new event api with .get and .set
 # Extent hsh with a recursive compact and deep freeze
 class Hash
   def compact

--- a/lib/logstash/filters/rest.rb
+++ b/lib/logstash/filters/rest.rb
@@ -133,6 +133,8 @@ class LogStash::Filters::Rest < LogStash::Filters::Base
       raise LogStash::ConfigurationError, "Invalid URL or request spec: '#{url_or_spec}', expected a String or Hash!"
     end
 
+    # TODO: passively find sprintf fields to not need to copy the complete object and to deprecate sprinft config
+
     validate_request!(url_or_spec, res)
     res
   end
@@ -189,6 +191,7 @@ class LogStash::Filters::Rest < LogStash::Filters::Base
 
   def filter(event)
     return unless filter?(event)
+    # TODO: instead of copying the complete object, only use and sprint the fields necessary
     request = Marshal.load(Marshal.dump(@request))
     @logger.debug? && @logger.debug('Initiated request', :request => request)
     request[2][:params] = sprint(@sprintf, @request[2][:params], event) if request[2].has_key?(:params)

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -10,7 +10,15 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+  s.files = Dir['lib/**/*',
+                'spec/**/*',
+                'vendor/**/*',
+                '*.gemspec',
+                '*.md',
+                'CONTRIBUTORS',
+                'Gemfile',
+                'LICENSE',
+                'NOTICE.TXT']
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
@@ -21,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
   s.add_runtime_dependency 'logstash-mixin-http_client', '>= 2.2.4', '< 5.0.0'
 
-  s.add_development_dependency 'logstash-devutils', '>= 0'
+  s.add_development_dependency 'logstash-devutils', '>= 0', '< 2.0.0'
 end

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-rest'
-  s.version = '0.2.2'
+  s.version = '0.3.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program'

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
   s.add_runtime_dependency 'logstash-mixin-http_client', '>= 2.2.4', '< 5.0.0'
 
-  s.add_development_dependency 'logstash-devutils', '~> 0'
+  s.add_development_dependency 'logstash-devutils', '>= 0'
 end

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-rest'
-  s.version = '0.2.1'
+  s.version = '0.2.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program'

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-rest'
-  s.version = '0.3.0'
+  s.version = '0.5.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program'
@@ -18,10 +18,8 @@ Gem::Specification.new do |s|
   s.metadata = { 'logstash_plugin' => 'true', 'logstash_group' => 'filter' }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '>= 1.6.0', '< 3.0.0'
-  s.add_runtime_dependency 'logstash-codec-json', '>= 1.6.0', '< 3.0.0'
+  s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
   s.add_runtime_dependency 'logstash-mixin-http_client', '>= 2.2.4', '< 5.0.0'
 
   s.add_development_dependency 'logstash-devutils', '~> 0'
-  s.add_development_dependency 'pry', '~> 0'
 end

--- a/spec/filters/rest_spec.rb
+++ b/spec/filters/rest_spec.rb
@@ -1,6 +1,7 @@
-require 'spec_helper'
+require 'logstash/devutils/rspec/spec_helper'
 require 'logstash/filters/rest'
 
+#TODO: new event api with .get and .set
 describe LogStash::Filters::Rest do
   describe "Set to Rest Filter Get without params" do
     let(:config) do <<-CONFIG

--- a/spec/filters/rest_spec.rb
+++ b/spec/filters/rest_spec.rb
@@ -206,6 +206,36 @@ describe LogStash::Filters::Rest do
       expect(subject['rest']).to_not include("fallback")
     end
   end
+  describe "Set to Rest Filter Post with body sprintf" do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => "https://jsonplaceholder.typicode.com/posts"
+            method => "post"
+            body => {
+              title => 'foo'
+              body => 'bar'
+              userId => "%{message}"
+            }
+            headers => {
+              "Content-Type" => "application/json"
+            }
+          }
+          json => true
+          sprintf => true
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "42") do
+      expect(subject).to include('rest')
+      expect(subject['rest']).to include("id")
+      expect(subject['rest']['userId']).to eq(42)
+      expect(subject['rest']).to_not include("fallback")
+    end
+  end
   describe "Fallback" do
     let(:config) do <<-CONFIG
       filter {

--- a/spec/filters/rest_spec.rb
+++ b/spec/filters/rest_spec.rb
@@ -118,6 +118,30 @@ describe LogStash::Filters::Rest do
       expect(subject.get('rest')).to_not include('fallback')
     end
   end
+  describe 'empty response' do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => 'https://jsonplaceholder.typicode.com/posts'
+            params => {
+              userId => 0
+            }
+            headers => {
+              'Content-Type' => 'application/json'
+            }
+          }
+          target => 'rest'
+        }
+      }
+    CONFIG
+    end
+
+    sample('message' => 'some text') do
+      expect(subject).to_not include('rest')
+      expect(subject.get('tags')).to include('_restfailure')
+    end
+  end
   describe 'Set to Rest Filter Get with params sprintf' do
     let(:config) do <<-CONFIG
       filter {

--- a/spec/filters/rest_spec.rb
+++ b/spec/filters/rest_spec.rb
@@ -51,7 +51,6 @@ describe LogStash::Filters::Rest do
             url => "http://jsonplaceholder.typicode.com/users/%{message}"
           }
           json => true
-          sprintf => true
         }
       }
     CONFIG
@@ -122,28 +121,24 @@ describe LogStash::Filters::Rest do
             url => "https://jsonplaceholder.typicode.com/posts"
             params => {
               userId => "%{message}"
+              id => "%{message}"
             }
             headers => {
               "Content-Type" => "application/json"
             }
           }
           json => true
-          sprintf => true
         }
       }
     CONFIG
     end
 
-    sample("message" => "10") do
+    sample("message" => "1") do
       expect(subject).to include('rest')
       expect(subject['rest'][0]).to include("userId")
-      expect(subject['rest'][0]['userId']).to eq(10)
-      expect(subject['rest']).to_not include("fallback")
-    end
-    sample("message" => "9") do
-      expect(subject).to include('rest')
-      expect(subject['rest'][0]).to include("userId")
-      expect(subject['rest'][0]['userId']).to eq(9)
+      expect(subject['rest'][0]['userId']).to eq(1)
+      expect(subject['rest'][0]['id']).to eq(1)
+      expect(subject['rest'].length).to eq(1)
       expect(subject['rest']).to_not include("fallback")
     end
   end
@@ -193,7 +188,6 @@ describe LogStash::Filters::Rest do
             }
           }
           json => true
-          sprintf => true
         }
       }
     CONFIG
@@ -223,7 +217,6 @@ describe LogStash::Filters::Rest do
             }
           }
           json => true
-          sprintf => true
         }
       }
     CONFIG

--- a/spec/filters/rest_spec.rb
+++ b/spec/filters/rest_spec.rb
@@ -1,34 +1,34 @@
 require 'logstash/devutils/rspec/spec_helper'
 require 'logstash/filters/rest'
 
-#TODO: new event api with .get and .set
 describe LogStash::Filters::Rest do
-  describe "Set to Rest Filter Get without params" do
+  describe 'Set to Rest Filter Get without params' do
     let(:config) do <<-CONFIG
       filter {
         rest {
           request => {
-            url => "http://jsonplaceholder.typicode.com/users/10"
+            url => 'http://jsonplaceholder.typicode.com/users/10'
           }
           json => true
+          target => 'rest'
         }
       }
     CONFIG
     end
 
-    sample("message" => "some text") do
+    sample('message' => 'some text') do
       expect(subject).to include('rest')
-      expect(subject['rest']).to include("id")
-      expect(subject['rest']['id']).to eq(10)
-      expect(subject['rest']).to_not include("fallback")
+      expect(subject.get('rest')).to include('id')
+      expect(subject.get('[rest][id]')).to eq(10)
+      expect(subject.get('rest')).to_not include('fallback')
     end
   end
-  describe "Set to Rest Filter Get without params custom target" do
+  describe 'Set to Rest Filter Get without params custom target' do
     let(:config) do <<-CONFIG
       filter {
         rest {
           request => {
-            url => "http://jsonplaceholder.typicode.com/users/10"
+            url => 'http://jsonplaceholder.typicode.com/users/10'
           }
           json => true
           target => 'testing'
@@ -37,14 +37,14 @@ describe LogStash::Filters::Rest do
     CONFIG
     end
 
-    sample("message" => "some text") do
+    sample('message' => 'some text') do
       expect(subject).to include('testing')
-      expect(subject['testing']).to include("id")
-      expect(subject['testing']['id']).to eq(10)
-      expect(subject['testing']).to_not include("fallback")
+      expect(subject.get('testing')).to include('id')
+      expect(subject.get('[testing][id]')).to eq(10)
+      expect(subject.get('testing')).to_not include('fallback')
     end
   end
-  describe "Set to Rest Filter Get without params and sprintf" do
+  describe 'Set to Rest Filter Get without params and sprintf' do
     let(:config) do <<-CONFIG
       filter {
         rest {
@@ -52,250 +52,256 @@ describe LogStash::Filters::Rest do
             url => "http://jsonplaceholder.typicode.com/users/%{message}"
           }
           json => true
+          sprintf => true
+          target => 'rest'
         }
       }
     CONFIG
     end
 
-    sample("message" => "10") do
+    sample('message' => '10') do
       expect(subject).to include('rest')
-      expect(subject['rest']).to include("id")
-      expect(subject['rest']['id']).to eq(10)
-      expect(subject['rest']).to_not include("fallback")
+      expect(subject.get('rest')).to include('id')
+      expect(subject.get('[rest][id]')).to eq(10)
+      expect(subject.get('rest')).to_not include('fallback')
     end
-    sample("message" => "9") do
+    sample('message' => '9') do
       expect(subject).to include('rest')
-      expect(subject['rest']).to include("id")
-      expect(subject['rest']['id']).to eq(9)
-      expect(subject['rest']).to_not include("fallback")
+      expect(subject.get('rest')).to include('id')
+      expect(subject.get('[rest][id]')).to eq(9)
+      expect(subject.get('rest')).to_not include('fallback')
     end
   end
-  describe "Set to Rest Filter Get without params http error" do
+  describe 'Set to Rest Filter Get without params http error' do
     let(:config) do <<-CONFIG
       filter {
         rest {
           request => {
-            url => "http://httpstat.us/404"
+            url => 'http://httpstat.us/404'
           }
           json => true
+          target => 'rest'
         }
       }
     CONFIG
     end
 
-    sample("message" => "some text") do
+    sample('message' => 'some text') do
       expect(subject).to_not include('rest')
-      expect(subject['tags']).to include('_restfailure')
+      expect(subject.get('tags')).to include('_restfailure')
     end
   end
-  describe "Set to Rest Filter Get with params" do
+  describe 'Set to Rest Filter Get with params' do
     let(:config) do <<-CONFIG
       filter {
         rest {
           request => {
-            url => "https://jsonplaceholder.typicode.com/posts"
+            url => 'https://jsonplaceholder.typicode.com/posts'
             params => {
               userId => 10
             }
             headers => {
-              "Content-Type" => "application/json"
+              'Content-Type' => 'application/json'
             }
           }
           json => true
+          target => 'rest'
         }
       }
     CONFIG
     end
 
-    sample("message" => "some text") do
+    sample('message' => 'some text') do
       expect(subject).to include('rest')
-      expect(subject['rest'][0]).to include("userId")
-      expect(subject['rest'][0]['userId']).to eq(10)
-      expect(subject['rest']).to_not include("fallback")
+      expect(subject.get('[rest][0]')).to include('userId')
+      expect(subject.get('[rest][0][userId]')).to eq(10)
+      expect(subject.get('rest')).to_not include('fallback')
     end
   end
-  describe "Set to Rest Filter Get with params sprintf" do
+  describe 'Set to Rest Filter Get with params sprintf' do
     let(:config) do <<-CONFIG
       filter {
         rest {
           request => {
-            url => "https://jsonplaceholder.typicode.com/posts"
+            url => 'https://jsonplaceholder.typicode.com/posts'
             params => {
               userId => "%{message}"
               id => "%{message}"
             }
             headers => {
-              "Content-Type" => "application/json"
+              'Content-Type' => 'application/json'
             }
           }
           json => true
+          target => 'rest'
         }
       }
     CONFIG
     end
 
-    sample("message" => "1") do
+    sample('message' => '1') do
       expect(subject).to include('rest')
-      expect(subject['rest'][0]).to include("userId")
-      expect(subject['rest'][0]['userId']).to eq(1)
-      expect(subject['rest'][0]['id']).to eq(1)
-      expect(subject['rest'].length).to eq(1)
-      expect(subject['rest']).to_not include("fallback")
+      expect(subject.get('[rest][0]')).to include('userId')
+      expect(subject.get('[rest][0][userId]')).to eq(1)
+      expect(subject.get('[rest][0][id]')).to eq(1)
+      expect(subject.get('rest').length).to eq(1)
+      expect(subject.get('rest')).to_not include('fallback')
     end
   end
-  describe "Set to Rest Filter Post with params" do
+  describe 'Set to Rest Filter Post with params' do
     let(:config) do <<-CONFIG
       filter {
         rest {
           request => {
-            url => "https://jsonplaceholder.typicode.com/posts"
-            method => "post"
+            url => 'https://jsonplaceholder.typicode.com/posts'
+            method => 'post'
             params => {
               title => 'foo'
               body => 'bar'
               userId => 42
             }
             headers => {
-              "Content-Type" => "application/json"
+              'Content-Type' => 'application/json'
             }
           }
           json => true
+          target => 'rest'
         }
       }
     CONFIG
     end
 
-    sample("message" => "some text") do
+    sample('message' => 'some text') do
       expect(subject).to include('rest')
-      expect(subject['rest']).to include("id")
-      expect(subject['rest']['userId']).to eq(42)
-      expect(subject['rest']).to_not include("fallback")
+      expect(subject.get('rest')).to include('id')
+      expect(subject.get('[rest][userId]')).to eq(42)
+      expect(subject.get('rest')).to_not include('fallback')
     end
   end
-  describe "Set to Rest Filter Post with params sprintf" do
+  describe 'Set to Rest Filter Post with params sprintf' do
     let(:config) do <<-CONFIG
       filter {
         rest {
           request => {
-            url => "https://jsonplaceholder.typicode.com/posts"
-            method => "post"
+            url => 'https://jsonplaceholder.typicode.com/posts'
+            method => 'post'
             params => {
               title => 'foo'
               body => 'bar'
               userId => "%{message}"
             }
             headers => {
-              "Content-Type" => "application/json"
+              'Content-Type' => 'application/json'
             }
           }
           json => true
+          target => 'rest'
         }
       }
     CONFIG
     end
 
-    sample("message" => "42") do
+    sample('message' => '42') do
       expect(subject).to include('rest')
-      expect(subject['rest']).to include("id")
-      expect(subject['rest']['userId']).to eq(42)
-      expect(subject['rest']).to_not include("fallback")
+      expect(subject.get('rest')).to include('id')
+      expect(subject.get('[rest][userId]')).to eq(42)
+      expect(subject.get('rest')).to_not include('fallback')
     end
   end
-  describe "Set to Rest Filter Post with body sprintf" do
+  describe 'Set to Rest Filter Post with body sprintf' do
     let(:config) do <<-CONFIG
       filter {
         rest {
           request => {
-            url => "https://jsonplaceholder.typicode.com/posts"
-            method => "post"
+            url => 'https://jsonplaceholder.typicode.com/posts'
+            method => 'post'
             body => {
               title => 'foo'
               body => 'bar'
               userId => "%{message}"
             }
             headers => {
-              "Content-Type" => "application/json"
+              'Content-Type' => 'application/json'
             }
           }
           json => true
+          target => 'rest'
         }
       }
     CONFIG
     end
 
-    sample("message" => "42") do
+    sample('message' => '42') do
       expect(subject).to include('rest')
-      expect(subject['rest']).to include("id")
-      expect(subject['rest']['userId']).to eq(42)
-      expect(subject['rest']).to_not include("fallback")
+      expect(subject.get('rest')).to include('id')
+      expect(subject.get('[rest][userId]')).to eq(42)
+      expect(subject.get('rest')).to_not include('fallback')
     end
   end
-  describe "Fallback" do
+  describe 'fallback' do
     let(:config) do <<-CONFIG
       filter {
         rest {
           request => {
-            url => "http://jsonplaceholder.typicode.com/users/0"
+            url => 'http://jsonplaceholder.typicode.com/users/0'
           }
           json => true
           fallback => {
-            "fallback1" => true
-            "fallback2" => true
+            'fallback1' => true
+            'fallback2' => true
           }
+          target => 'rest'
         }
       }
     CONFIG
     end
 
-    sample("message" => "some text") do
+    sample('message' => 'some text') do
       expect(subject).to include('rest')
-      expect(subject['rest']).to include("fallback1")
-      expect(subject['rest']).to include("fallback2")
-      expect(subject['rest']).to_not include("id")
+      expect(subject.get('rest')).to include('fallback1')
+      expect(subject.get('rest')).to include('fallback2')
+      expect(subject.get('rest')).to_not include('id')
     end
   end
-  describe "Fallback empty target" do
+  describe 'empty target exception' do
     let(:config) do <<-CONFIG
       filter {
         rest {
           request => {
-            url => "http://jsonplaceholder.typicode.com/users/0"
+            url => 'http://jsonplaceholder.typicode.com/users/0'
           }
           json => true
-          target => ''
           fallback => {
-            "fallback1" => true
-            "fallback2" => true
+            'fallback1' => true
+            'fallback2' => true
           }
-        }
-      }
-    CONFIG
-    end
-
-    sample("message" => "some text") do
-      expect(subject).to_not include('rest')
-      expect(subject).to include("fallback1")
-      expect(subject).to include("fallback2")
-      expect(subject).to_not include("id")
-    end
-  end
-  describe "Empty target" do
-    let(:config) do <<-CONFIG
-      filter {
-        rest {
-          request => {
-            url => "http://jsonplaceholder.typicode.com/users/1"
-          }
-          json => true
           target => ''
         }
       }
     CONFIG
     end
-
-    sample("message" => "some text") do
-      expect(subject).to include("id")
-      expect(subject).to_not include("fallback")
+    sample('message' => 'some text') do
+      expect { subject }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+  describe 'missing target exception' do
+    let(:config) do <<-CONFIG
+      filter {
+        rest {
+          request => {
+            url => 'http://jsonplaceholder.typicode.com/users/0'
+          }
+          json => true
+          fallback => {
+            'fallback1' => true
+            'fallback2' => true
+          }
+        }
+      }
+    CONFIG
+    end
+    sample('message' => 'some text') do
+      expect { subject }.to raise_error(LogStash::ConfigurationError)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,0 @@
-require 'logstash/devutils/rspec/spec_helper'
-require 'pry'


### PR DESCRIPTION
I wrote down the changes in the CHANGELOG and tested the common bug of not reassigning the fields with the commands in the README.
For an easier usage of the Event API (#get, #set), a target needs to be defined. If it is needed in the event top-level, a mutate { rename => ... } after the rest { .. } might be suitable.

For now it looks good and the plugin can be run with logstash 5.0.0
With 2.x it is not executable anymore, so maybe #11 should be published as well.

Plugin version set to 0.5.0