### PR TITLE
bugfix/field-interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.0
+  - Fix behavior, where a referenced field (`%{...}`) has `ruby` chars
+  (i.e., consisting of `:`)
+  - Field interpolation is done by assigning explicit values instead
+  of converting the `sprintf` string back into a `hash`
+
 ## 0.5.0
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
   - Require devutils >= 0 to make `bundler` update the package

--- a/lib/logstash/filters/rest.rb
+++ b/lib/logstash/filters/rest.rb
@@ -16,16 +16,6 @@ class Hash
   end
 end
 
-# Monkey Patch string to parse to hsh
-class String
-  def to_object(symbolize = true)
-    LogStash::Json.load(
-      gsub(/:([\w]+)=>/, '"\\1"=>').gsub('=>', ': '),
-      :symbolize_keys => symbolize
-    )
-  end
-end
-
 #  Monkey Patch Array with deep freeze
 class Array
   def deep_freeze

--- a/logstash-filter-rest.gemspec
+++ b/logstash-filter-rest.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-rest'
-  s.version = '0.5.1'
+  s.version = '0.6.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-filter-rest. This gem is not a stand-alone program'

--- a/spec/filters/rest_spec.rb
+++ b/spec/filters/rest_spec.rb
@@ -210,7 +210,7 @@ describe LogStash::Filters::Rest do
             url => 'https://jsonplaceholder.typicode.com/posts'
             method => 'post'
             params => {
-              title => 'foo'
+              title => '%{message}'
               body => 'bar'
               userId => "%{message}"
             }
@@ -228,7 +228,22 @@ describe LogStash::Filters::Rest do
     sample('message' => '42') do
       expect(subject).to include('rest')
       expect(subject.get('rest')).to include('id')
+      expect(subject.get('[rest][title]')).to eq(42)
       expect(subject.get('[rest][userId]')).to eq(42)
+      expect(subject.get('rest')).to_not include('fallback')
+    end
+    sample('message' => ':5e?#!-_') do
+      expect(subject).to include('rest')
+      expect(subject.get('rest')).to include('id')
+      expect(subject.get('[rest][title]')).to eq(':5e?#!-_')
+      expect(subject.get('[rest][userId]')).to eq(':5e?#!-_')
+      expect(subject.get('rest')).to_not include('fallback')
+    end
+    sample('message' => ':4c43=>') do
+      expect(subject).to include('rest')
+      expect(subject.get('rest')).to include('id')
+      expect(subject.get('[rest][title]')).to eq(':4c43=>')
+      expect(subject.get('[rest][userId]')).to eq(':4c43=>')
       expect(subject.get('rest')).to_not include('fallback')
     end
   end


### PR DESCRIPTION
This should be more robust in terms of "special" characters to take care of #19
Testcases added with special characters to `sprintf`.